### PR TITLE
Add support for unprocessed properties

### DIFF
--- a/src/main/kotlin/com/github/erosb/jsonsKema/Schema.kt
+++ b/src/main/kotlin/com/github/erosb/jsonsKema/Schema.kt
@@ -20,7 +20,8 @@ data class CompositeSchema(
     val propertySchemas: Map<String, Schema> = emptyMap(),
     val patternPropertySchemas: Map<Regexp, Schema> = emptyMap(),
     val unevaluatedItemsSchema: Schema? = null,
-    val unevaluatedPropertiesSchema: Schema? = null
+    val unevaluatedPropertiesSchema: Schema? = null,
+    val unprocessedProperties: Map<IJsonString, IJsonValue> = emptyMap()
 ) : Schema(location) {
     override fun <P> accept(visitor: SchemaVisitor<P>) = visitor.internallyVisitCompositeSchema(this)
     override fun subschemas() = subschemas

--- a/src/main/kotlin/com/github/erosb/jsonsKema/SchemaLoader.kt
+++ b/src/main/kotlin/com/github/erosb/jsonsKema/SchemaLoader.kt
@@ -444,7 +444,6 @@ class SchemaLoader(
                     { loadChild(it) },
                     regexpFactory
                 )
-                var processed = true
                 when (name.value) {
                     Keyword.PROPERTIES.value -> propertySchemas = loadPropertySchemas(value.requireObject())
                     Keyword.PATTERN_PROPERTIES.value -> patternPropertySchemas = loadPatternPropertySchemas(value.requireObject())
@@ -459,14 +458,13 @@ class SchemaLoader(
                     Keyword.DEFAULT.value -> default = value
                     Keyword.UNEVALUATED_ITEMS.value -> unevaluatedItemsSchema = UnevaluatedItemsSchema(loadChild(value), name.location)
                     Keyword.UNEVALUATED_PROPERTIES.value -> unevaluatedPropertiesSchema = UnevaluatedPropertiesSchema(loadChild(value), name.location)
-                    else -> processed = false
                 }
                 val loader = keywordLoaders[name.value]
                 if (subschema === null && loader != null) {
                     subschema = loader(ctx)
                 }
                 if (subschema != null) subschemas.add(subschema)
-                if (!processed && loader == null) {
+                if (!isKnownKeyword(name.value)) {
                     unprocessedProperties[name] = value
                 }
             }

--- a/src/main/kotlin/com/github/erosb/jsonsKema/SchemaVisitor.kt
+++ b/src/main/kotlin/com/github/erosb/jsonsKema/SchemaVisitor.kt
@@ -113,7 +113,8 @@ abstract class SchemaVisitor<P> {
     open fun visitUnevaluatedPropertiesSchema(schema: UnevaluatedPropertiesSchema): P? = visitChildren(schema)
     open fun visitFormatSchema(schema: FormatSchema): P? = visitChildren(schema)
 
-    open fun identity(parent: Schema): P? = null
+    open fun identity(): P? = null
+    open fun identity(parent: Schema): P? = identity()
     open fun accumulate(parent: Schema, previous: P?, current: P?): P? = current ?: previous
     open fun visitChildren(parent: Schema): P? {
         var product: P? = identity(parent)

--- a/src/main/kotlin/com/github/erosb/jsonsKema/SchemaVisitor.kt
+++ b/src/main/kotlin/com/github/erosb/jsonsKema/SchemaVisitor.kt
@@ -113,10 +113,10 @@ abstract class SchemaVisitor<P> {
     open fun visitUnevaluatedPropertiesSchema(schema: UnevaluatedPropertiesSchema): P? = visitChildren(schema)
     open fun visitFormatSchema(schema: FormatSchema): P? = visitChildren(schema)
 
-    open fun identity(): P? = null
+    open fun identity(parent: Schema): P? = null
     open fun accumulate(parent: Schema, previous: P?, current: P?): P? = current ?: previous
     open fun visitChildren(parent: Schema): P? {
-        var product: P? = identity()
+        var product: P? = identity(parent)
         for (subschema in parent.subschemas()) {
             val current = subschema.accept(this)
             product = accumulate(parent, product, current)

--- a/src/test/kotlin/com/github/erosb/jsonsKema/SchemaLoaderTest.kt
+++ b/src/test/kotlin/com/github/erosb/jsonsKema/SchemaLoaderTest.kt
@@ -90,7 +90,8 @@ class SchemaLoaderTest {
                 "writeOnly": false,
                 "readOnly": true,
                 "deprecated": false,
-                "default": null
+                "default": null,
+                "dummy": "hi"
             }
             """.trimIndent()
         )()
@@ -102,7 +103,8 @@ class SchemaLoaderTest {
             readOnly = JsonBoolean(true),
             writeOnly = JsonBoolean(false),
             deprecated = JsonBoolean(false),
-            default = JsonNull()
+            default = JsonNull(),
+            unprocessedProperties = mutableMapOf(JsonString("dummy") to JsonString("hi"))
         )
         assertThat(actual).usingRecursiveComparison()
             .ignoringFieldsOfTypes(SourceLocation::class.java)

--- a/src/test/kotlin/com/github/erosb/jsonsKema/SchemaLoaderTest.kt
+++ b/src/test/kotlin/com/github/erosb/jsonsKema/SchemaLoaderTest.kt
@@ -91,12 +91,19 @@ class SchemaLoaderTest {
                 "readOnly": true,
                 "deprecated": false,
                 "default": null,
+                "if": false,
+                "then": true,
                 "dummy": "hi"
             }
             """.trimIndent()
         )()
         val expected = CompositeSchema(
-            subschemas = emptySet(),
+            subschemas = setOf(
+                IfThenElseSchema(
+                    FalseSchema(SourceLocation(8, 11, pointer("#/if"))),
+                    TrueSchema(SourceLocation(9, 13, pointer("#/then"))),
+                    null,
+                    SourceLocation(8, 5, pointer("#/if")))),
             location = UnknownSource,
             title = JsonString("My title"),
             description = JsonString("My description"),


### PR DESCRIPTION
Hi erosb,

Thanks for your effort in providing useful libraries for JSON Schema.  I am one of the engineers at Confluent that actively maintains the [Confluent Schema Registry](https://github.com/confluentinc/schema-registry).  We've been using your [previous library](https://github.com/everit-org/json-schema) and we would like to add support for JSON Schema 2020-12 to the Confluent Schema Registry using this library.  One of the features of the previous library that we depend upon is the collection of unprocessed properties.  This PR attempts to add support for unprocessed properties to this library.

I've also added a small change to the signature of `identity` that would help us, but I can omit that change if you like.

Thanks in advance!