### PR TITLE
Add dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+registries:
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    open-pull-requests-limit: 50
+    schedule:
+      interval: monthly
+  - package-ecosystem: maven
+    directory: /
+    open-pull-requests-limit: 50
+    schedule:
+      interval: monthly


### PR DESCRIPTION
part of: https://github.com/erosb/json-sKema/issues/31

This change adds a dependabot config file. With this, dependabot should raise PRs at the start of each month to update `maven`, i.e. code, dependencies and `github-actions`, i.e. workflow, dependencies.

Merging this PR should prompt dependabot to do an initial scan. This may mean you get a few PRs to review.

If no PRs are raised, then someone with admin rights may still need to enable the feature in the repositories settings:

1. Merge this PR.
2. Go to: https://github.com/erosb/json-sKema/settings/security_analysis
3. Search for "Dependabot version updates" and check it is not disabled.

docs: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuring-dependabot-version-updates#enabling-dependabot-version-updates