### PR TITLE
Improve error message for invalid schema

### DIFF
--- a/src/main/kotlin/com/github/erosb/jsonsKema/SchemaLoader.kt
+++ b/src/main/kotlin/com/github/erosb/jsonsKema/SchemaLoader.kt
@@ -21,7 +21,9 @@ data class SchemaLoaderConfig(val schemaClient: SchemaClient, val initialBaseURI
     }
 }
 
-class SchemaLoadingException(msg: String, cause: Throwable) : RuntimeException(msg, cause)
+class SchemaLoadingException(msg: String, cause: Throwable?) : RuntimeException(msg, cause) {
+    constructor(msg: String): this(msg, null)
+}
 
 internal fun createDefaultConfig(additionalMappings: Map<URI, String> = mapOf()) = SchemaLoaderConfig.createDefaultConfig(additionalMappings)
 
@@ -204,7 +206,7 @@ class SchemaLoader(
                         ?.toList()
                     } ?: emptyList()
             }
-            else -> TODO()
+            else -> throw SchemaLoadingException("unexpected schema : $schemaJson")
         }
     }
 
@@ -450,7 +452,7 @@ class SchemaLoader(
                     }
 
                     is IJsonObject<*, *> -> createCompositeSchema(schemaJson)
-                    else -> TODO()
+                    else -> throw SchemaLoadingException("unexpected schema : $schemaJson")
                 }
         return retval
     }

--- a/src/main/kotlin/com/github/erosb/jsonsKema/SchemaLoader.kt
+++ b/src/main/kotlin/com/github/erosb/jsonsKema/SchemaLoader.kt
@@ -21,9 +21,7 @@ data class SchemaLoaderConfig(val schemaClient: SchemaClient, val initialBaseURI
     }
 }
 
-class SchemaLoadingException(msg: String, cause: Throwable?) : RuntimeException(msg, cause) {
-    constructor(msg: String): this(msg, null)
-}
+class SchemaLoadingException(msg: String, cause: Throwable) : RuntimeException(msg, cause)
 
 internal fun createDefaultConfig(additionalMappings: Map<URI, String> = mapOf()) = SchemaLoaderConfig.createDefaultConfig(additionalMappings)
 
@@ -206,7 +204,8 @@ class SchemaLoader(
                         ?.toList()
                     } ?: emptyList()
             }
-            else -> throw SchemaLoadingException("unexpected schema : $schemaJson")
+            else -> throw JsonTypingException("boolean or object",
+                schemaJson.jsonTypeAsString(), schemaJson.location)
         }
     }
 
@@ -452,7 +451,8 @@ class SchemaLoader(
                     }
 
                     is IJsonObject<*, *> -> createCompositeSchema(schemaJson)
-                    else -> throw SchemaLoadingException("unexpected schema : $schemaJson")
+                    else -> throw JsonTypingException("boolean or object",
+                        schemaJson.jsonTypeAsString(), schemaJson.location)
                 }
         return retval
     }

--- a/src/test/kotlin/com/github/erosb/jsonsKema/SchemaLoaderTest.kt
+++ b/src/test/kotlin/com/github/erosb/jsonsKema/SchemaLoaderTest.kt
@@ -121,7 +121,7 @@ class SchemaLoaderTest {
 
     @Test
     fun `obsolete use of items`() {
-        val exception = assertThrows(SchemaLoadingException::class.java) {
+        val exception = assertThrows(JsonTypingException::class.java) {
             createSchemaLoaderForString(
                 """
                 { 
@@ -132,6 +132,6 @@ class SchemaLoaderTest {
                 """.trimIndent()
             )()
         }
-        assertThat(exception.message).startsWith("unexpected schema")
+        assertThat(exception.message).contains("boolean or object")
     }
 }

--- a/src/test/kotlin/com/github/erosb/jsonsKema/SchemaLoaderTest.kt
+++ b/src/test/kotlin/com/github/erosb/jsonsKema/SchemaLoaderTest.kt
@@ -1,6 +1,7 @@
 package com.github.erosb.jsonsKema
 
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
 import java.io.ByteArrayInputStream
 import java.io.IOException
@@ -116,5 +117,21 @@ class SchemaLoaderTest {
         assertThat(actual).usingRecursiveComparison()
             .ignoringFieldsOfTypes(SourceLocation::class.java)
             .isEqualTo(expected)
+    }
+
+    @Test
+    fun `obsolete use of items`() {
+        val exception = assertThrows(SchemaLoadingException::class.java) {
+            createSchemaLoaderForString(
+                """
+                { 
+                    "type": "array", 
+                    "title": "array desc", 
+                    "items": [ {"type": "object", "title": "some obj"} ] 
+                }
+                """.trimIndent()
+            )()
+        }
+        assertThat(exception.message).startsWith("unexpected schema")
     }
 }


### PR DESCRIPTION
When parsing a large schema that uses `"items": [ ... ] ` instead of `"prefixItems": [ ... ] `, the error message is cryptic, and appears as `kotlin.NotImplementedError`, as shown below.  This PR attempts to make the error message more helpful.   

Related is https://github.com/erosb/json-sKema/issues/27

```
Caused by: kotlin.NotImplementedError: An operation is not implemented.
        at com.github.erosb.jsonsKema.SchemaLoader.doLoadSchema(SchemaLoader.kt:425)
        at com.github.erosb.jsonsKema.SchemaLoader.loadChild$json_sKema(SchemaLoader.kt:514)
        at com.github.erosb.jsonsKema.SchemaLoader$createCompositeSchema$1$1$ctx$1.invoke(SchemaLoader.kt:450)
        at com.github.erosb.jsonsKema.SchemaLoader$createCompositeSchema$1$1$ctx$1.invoke(SchemaLoader.kt:448)
        at com.github.erosb.jsonsKema.ItemsKt$itemsSchemaLoader$1.invoke(Items.kt:10)
        at com.github.erosb.jsonsKema.ItemsKt$itemsSchemaLoader$1.invoke(Items.kt:8)
        at com.github.erosb.jsonsKema.SchemaLoader$createCompositeSchema$1.invoke(SchemaLoader.kt:470)
        at com.github.erosb.jsonsKema.SchemaLoader$createCompositeSchema$1.invoke(SchemaLoader.kt:445)
        at com.github.erosb.jsonsKema.SchemaLoader.enterScope(SchemaLoader.kt:175)
        at com.github.erosb.jsonsKema.SchemaLoader.createCompositeSchema(SchemaLoader.kt:445)
        at com.github.erosb.jsonsKema.SchemaLoader.doLoadSchema(SchemaLoader.kt:424)
        at com.github.erosb.jsonsKema.SchemaLoader.loadChild$json_sKema(SchemaLoader.kt:514)
        at com.github.erosb.jsonsKema.SchemaLoader.loadPropertySchemas(SchemaLoader.kt:508)
        at com.github.erosb.jsonsKema.SchemaLoader.access$loadPropertySchemas(SchemaLoader.kt:106)
        at com.github.erosb.jsonsKema.SchemaLoader$createCompositeSchema$1.invoke(SchemaLoader.kt:454)
        at com.github.erosb.jsonsKema.SchemaLoader$createCompositeSchema$1.invoke(SchemaLoader.kt:445)
        at com.github.erosb.jsonsKema.SchemaLoader.enterScope(SchemaLoader.kt:175)
        at com.github.erosb.jsonsKema.SchemaLoader.createCompositeSchema(SchemaLoader.kt:445)
        at com.github.erosb.jsonsKema.SchemaLoader.doLoadSchema(SchemaLoader.kt:424)
        at com.github.erosb.jsonsKema.SchemaLoader.loadChild$json_sKema(SchemaLoader.kt:514)
        at com.github.erosb.jsonsKema.SchemaLoader.loadPropertySchemas(SchemaLoader.kt:508)
        at com.github.erosb.jsonsKema.SchemaLoader.access$loadPropertySchemas(SchemaLoader.kt:106)
        at com.github.erosb.jsonsKema.SchemaLoader$createCompositeSchema$1.invoke(SchemaLoader.kt:454)
        at com.github.erosb.jsonsKema.SchemaLoader$createCompositeSchema$1.invoke(SchemaLoader.kt:445)
        at com.github.erosb.jsonsKema.SchemaLoader.enterScope(SchemaLoader.kt:175)
        at com.github.erosb.jsonsKema.SchemaLoader.createCompositeSchema(SchemaLoader.kt:445)
        at com.github.erosb.jsonsKema.SchemaLoader.doLoadSchema(SchemaLoader.kt:424)
        at com.github.erosb.jsonsKema.SchemaLoader.loadSchema(SchemaLoader.kt:318)
        at com.github.erosb.jsonsKema.SchemaLoader.loadRootSchema(SchemaLoader.kt:292)
        at com.github.erosb.jsonsKema.SchemaLoader.load(SchemaLoader.kt:184)
        at io.confluent.kafka.schemaregistry.json.JsonSchema.loadLatestDraft(JsonSchema.java:373)
        at io.confluent.kafka.schemaregistry.json.JsonSchema.rawSchema(JsonSchema.java:338)
        ... 97 more
```