### PR TITLE
Allow registering schemas with URIs that are not absolute

### DIFF
--- a/src/main/kotlin/com/github/erosb/jsonsKema/SchemaLoader.kt
+++ b/src/main/kotlin/com/github/erosb/jsonsKema/SchemaLoader.kt
@@ -7,7 +7,11 @@ import java.nio.charset.StandardCharsets
 import java.util.*
 import java.util.stream.Collectors.toList
 
-data class SchemaLoaderConfig(val schemaClient: SchemaClient, val initialBaseURI: String = DEFAULT_BASE_URI) {
+data class SchemaLoaderConfig @JvmOverloads constructor(
+    val schemaClient: SchemaClient,
+    val initialBaseURI: String = DEFAULT_BASE_URI,
+    val additionalMappings: Map<URI, String> = mapOf()
+) {
     companion object {
         @JvmStatic
         fun createDefaultConfig(additionalMappings: Map<URI, String> = mapOf()) = SchemaLoaderConfig(
@@ -16,7 +20,8 @@ data class SchemaLoaderConfig(val schemaClient: SchemaClient, val initialBaseURI
                     ClassPathAwareSchemaClient(DefaultSchemaClient()),
                     additionalMappings
                 )
-            )
+            ),
+            additionalMappings = additionalMappings
         )
     }
 }
@@ -254,7 +259,7 @@ class SchemaLoader(
     private fun resolveRelativeURI(ref: String): URI {
         return try {
             val uri = URI(ref)
-            if (uri.isAbsolute) {
+            if (uri.isAbsolute || config.additionalMappings.containsKey(parseUri(ref).toBeQueried)) {
                 uri
             } else{
                 resolveAgainstBaseURI(ref)

--- a/src/test/kotlin/com/github/erosb/jsonsKema/RefResolutionTest.kt
+++ b/src/test/kotlin/com/github/erosb/jsonsKema/RefResolutionTest.kt
@@ -551,4 +551,106 @@ class RefResolutionTest {
             )
         )() as CompositeSchema
     }
+
+    @Test
+    fun `additional mappings with no scheme`() {
+        val schema =
+            SchemaLoader(
+                JsonParser("""
+                    {
+                      "$schema" : "https://json-schema.org/draft/2020-12/schema",
+                      "type" : "object",
+                      "properties" : {
+                        "applicationSchema" : {
+                          "$ref" : "#/$defs/ApplicationSchema"
+                        },
+                        "additionalProperties" : false
+                      },
+                      "$defs" : {
+                        "ApplicationSchema" : {
+                          "type" : "object",
+                          "properties" : {
+                            "protocolVersion" : {
+                              "type" : "array",
+                              "minItems" : 0,
+                              "items" : {
+                                "$ref" : "child.schema.json#/$defs/ProtocolVersionName"
+                              }
+                            }
+                          },
+                          "additionalProperties" : false
+                        }
+                      },
+                      "additionalProperties" : false
+                    }
+                """)(), config =
+                createDefaultConfig(
+                    mapOf(
+                        URI("child.schema.json") to
+                                """
+                                    {
+                                        "$schema": "https://json-schema.org/draft/2020-12/schema",
+                                        "type": "object",
+                                        "properties": {
+                                            "message": {
+                                                "$ref": "#/$defs/Message"
+                                            },
+                                            "additionalProperties": false
+                                        },
+                                        "$defs": {
+                                            "Message": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "messageId": {
+                                                        "$ref": "grandchild.schema.json#/$defs/MessageId"
+                                                    }
+                                                },
+                                                "additionalProperties": false
+                                            },
+                                            "ProtocolVersionName": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "version": {
+                                                        "type": "string"
+                                                    },
+                                                    "name": {
+                                                        "type": "string"
+                                                    }
+                                                },
+                                                "required": [
+                                                    "name",
+                                                    "version"
+                                                ],
+                                                "additionalProperties": false
+                                            }
+                                        },
+                                        "additionalProperties": false
+                                    }
+                                """.trimIndent(),
+                        URI("grandchild.schema.json") to
+                                """
+                                    {
+                                        "$schema": "https://json-schema.org/draft/2020-12/schema",
+                                        "type": "object",
+                                        "properties": {
+                                            "additionalProperties": false
+                                        },
+                                        "$defs": {
+                                            "MessageId": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "id": {
+                                                        "type": "string"
+                                                    }
+                                                }
+                                                "additionalProperties": false
+                                            }
+                                        },
+                                        "additionalProperties": false
+                                    }
+                                """.trimIndent()
+                    )
+                )
+            )() as CompositeSchema
+    }
 }

--- a/src/test/kotlin/com/github/erosb/jsonsKema/RefResolutionTest.kt
+++ b/src/test/kotlin/com/github/erosb/jsonsKema/RefResolutionTest.kt
@@ -553,7 +553,7 @@ class RefResolutionTest {
     }
 
     @Test
-    fun `additional mappings with no scheme`() {
+    fun `additional mappings with non-absolute uris`() {
         val schema =
             SchemaLoader(
                 JsonParser("""


### PR DESCRIPTION
This PR allows registering schemas with URIs that are not absolute, which was supported by the previous everit-json-schema library.  This will enable customers to upgrade their schemas to draft 2020-12 with the Confluent Schema Registry.

Fixes #54 