### PR TITLE
throw json parsing exception when an expected comma character is missing in an object or array

### DIFF
--- a/src/main/kotlin/com/github/erosb/jsonsKema/JsonParser.kt
+++ b/src/main/kotlin/com/github/erosb/jsonsKema/JsonParser.kt
@@ -169,8 +169,9 @@ class JsonParser private constructor(
                     walker.forward()
                 }
                 walker.skipWhitespaces()
+                val curr = walker.curr()
                 if (!commaCharFound && walker.curr() != ']') {
-                    throw JsonParseException("unexpected character", sourceLocation())
+                    throw JsonParseException("Unexpected character found: $curr. Expected ',', ']'", sourceLocation())
                 }
             }
             walker.forward()
@@ -191,8 +192,9 @@ class JsonParser private constructor(
                     walker.forward()
                 }
                 walker.skipWhitespaces()
-                if (!commaCharFound && walker.curr() != '}') {
-                    throw JsonParseException("unexpected character", sourceLocation())
+                val curr = walker.curr()
+                if (!commaCharFound && curr != '}') {
+                    throw JsonParseException("Unexpected character found: $curr. Expected ',', '}'", sourceLocation())
                 }
             }
             walker.forward()

--- a/src/main/kotlin/com/github/erosb/jsonsKema/JsonParser.kt
+++ b/src/main/kotlin/com/github/erosb/jsonsKema/JsonParser.kt
@@ -159,14 +159,19 @@ class JsonParser private constructor(
             walker.skipWhitespaces()
             val elements = mutableListOf<JsonValue>()
             while (walker.curr() != ']') {
+                var commaCharFound = false
                 nestingPath.add(elements.size.toString().intern())
                 val element = parseValue()
                 elements.add(element)
                 nestingPath.removeLast()
                 if (walker.curr() == ',') {
+                    commaCharFound = true
                     walker.forward()
                 }
                 walker.skipWhitespaces()
+                if (!commaCharFound && walker.curr() != ']') {
+                    throw JsonParseException("unexpected character", sourceLocation())
+                }
             }
             walker.forward()
             jsonValue = JsonArray(elements.toList(), location)
@@ -175,15 +180,20 @@ class JsonParser private constructor(
             walker.forward()
             walker.skipWhitespaces()
             while (walker.curr() != '}') {
+                var commaCharFound = false
                 val propName = parseString(true)
                 walker.skipWhitespaces().consume(":").skipWhitespaces()
                 val propValue = parseValue()
                 nestingPath.removeLast()
                 properties.put(propName, propValue)
                 if (walker.curr() == ',') {
+                    commaCharFound = true
                     walker.forward()
                 }
                 walker.skipWhitespaces()
+                if (!commaCharFound && walker.curr() != '}') {
+                    throw JsonParseException("unexpected character", sourceLocation())
+                }
             }
             walker.forward()
             jsonValue = JsonObject(properties.toMap(), location)

--- a/src/test/kotlin/com/github/erosb/jsonsKema/JsonParserTest.kt
+++ b/src/test/kotlin/com/github/erosb/jsonsKema/JsonParserTest.kt
@@ -129,7 +129,7 @@ class JsonParserTest {
         val exception = assertThrows(JsonParseException::class.java) {
             JsonParser("{\"key1\":\"value1\", \"key2\":\"value2\" \"key3\":\"value3\"}\n")()
         }
-        assertEquals(JsonParseException("unexpected character", SourceLocation(1, 35, pointer())), exception)
+        assertEquals(JsonParseException("Unexpected character found: \". Expected ',', '}'", SourceLocation(1, 35, pointer())), exception)
     }
 
     @Test
@@ -137,7 +137,7 @@ class JsonParserTest {
         val exception = assertThrows(JsonParseException::class.java) {
             JsonParser("[1, 2 3]")()
         }
-        assertEquals(JsonParseException("unexpected character", SourceLocation(1, 7, pointer())), exception)
+        assertEquals(JsonParseException("Unexpected character found: 3. Expected ',', ']'", SourceLocation(1, 7, pointer())), exception)
     }
 
     @Test

--- a/src/test/kotlin/com/github/erosb/jsonsKema/JsonParserTest.kt
+++ b/src/test/kotlin/com/github/erosb/jsonsKema/JsonParserTest.kt
@@ -125,6 +125,22 @@ class JsonParserTest {
     }
 
     @Test
+    fun `missing comma character in object`() {
+        val exception = assertThrows(JsonParseException::class.java) {
+            JsonParser("{\"key1\":\"value1\", \"key2\":\"value2\" \"key3\":\"value3\"}\n")()
+        }
+        assertEquals(JsonParseException("unexpected character", SourceLocation(1, 35, pointer())), exception)
+    }
+
+    @Test
+    fun `missing comma character in array`() {
+        val exception = assertThrows(JsonParseException::class.java) {
+            JsonParser("[1, 2 3]")()
+        }
+        assertEquals(JsonParseException("unexpected character", SourceLocation(1, 7, pointer())), exception)
+    }
+
+    @Test
     fun `string parsing`() {
         val actual = JsonParser("  \"string literal\"  ")()
         val expected = JsonString("string literal", SourceLocation(1, 3, pointer()))


### PR DESCRIPTION
The JsonParser fails to detect that a missing comma character in an object or array is an invalid json.
I have added a couple of test cases to show the issue.