### PR TITLE
naive regex check for uuid format (#170)

### DIFF
--- a/src/main/kotlin/com/github/erosb/jsonsKema/Format.kt
+++ b/src/main/kotlin/com/github/erosb/jsonsKema/Format.kt
@@ -143,8 +143,11 @@ internal val timeFormatValidator: FormatValidator = {inst, schema -> inst.maybeS
     }
 }}
 
+internal val uuidRegex: Regex =
+    "^[0-9a-fA-F]{8}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{4}\\b-[0-9a-fA-F]{12}\$".toRegex()
+
 internal val uuidFormatValidator: FormatValidator = {inst, schema -> inst.maybeString { str ->
-    if (str.value.length == 36)
+    if (uuidRegex.matches(str.value))
     try {
         UUID.fromString(str.value)
         null

--- a/src/test/kotlin/com/github/erosb/jsonsKema/FormatTest.kt
+++ b/src/test/kotlin/com/github/erosb/jsonsKema/FormatTest.kt
@@ -41,6 +41,18 @@ class FormatTest {
     }
 
     @Test
+    fun uuid_shiftedDashes() {
+        val instance = JsonString("2eb8aa0-8aa98-11e-ab4aa7-3b441d16380")
+
+        val uuidSchema = FormatSchema("uuid", UnknownSource)
+
+        val actual = Validator.create(uuidSchema, ValidatorConfig(validateFormat = FormatValidationPolicy.ALWAYS))
+            .validate(instance)
+
+        assertThat(actual).isNotNull()
+    }
+
+    @Test
     fun `custom format`() {
         val validator = Validator.create(SchemaLoader("""
             {


### PR DESCRIPTION
Replace length check in UUID validator with regex to avoid accepting values with "shifted" dashes.