### PR TITLE
Replace formatter with regex in RFC 3339 date-time format check (#169)

### DIFF
--- a/src/main/kotlin/com/github/erosb/jsonsKema/Format.kt
+++ b/src/main/kotlin/com/github/erosb/jsonsKema/Format.kt
@@ -29,21 +29,14 @@ internal val dateFormatValidator: FormatValidator = { inst, schema -> inst.maybe
     }
 }}
 
-private val DATE_TIME_FORMATTER: DateTimeFormatter = run {
-    val secondsFractionFormatter = DateTimeFormatterBuilder()
-        .appendFraction(ChronoField.NANO_OF_SECOND, 1, 9, true)
-        .toFormatter()
-    DateTimeFormatterBuilder()
-        .appendPattern("yyyy-MM-dd'T'HH:mm:ss")
-        .appendOptional(secondsFractionFormatter)
-        .appendPattern("XXX")
-        .toFormatter()
-        .withResolverStyle(ResolverStyle.STRICT)
-}
+private val dateTimeRegex: Regex =
+    "^((\\d{4}-\\d{2}-\\d{2})[Tt](\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?)([Zz]|[+-]\\d{2}:\\d{2})?)$".toRegex()
 
 private fun validateDateTime(str: IJsonString, schema: FormatSchema): FormatValidationFailure? {
+    if(!dateTimeRegex.matches(str.value)) {
+        return FormatValidationFailure(schema, str)
+    }
     try {
-        DATE_TIME_FORMATTER.parse(str.value.uppercase())
         ZonedDateTime.parse(str.value)
     } catch (e: DateTimeParseException) {
         if ((e.message?.indexOf("Invalid value for SecondOfMinute") ?: -1) > -1) {

--- a/src/test/kotlin/com/github/erosb/jsonsKema/FormatTest.kt
+++ b/src/test/kotlin/com/github/erosb/jsonsKema/FormatTest.kt
@@ -30,6 +30,16 @@ class FormatTest {
     }
 
     @Test
+    fun date_time_extendedYear() {
+        val instance = JsonString("+11990-03-31T15:59:59.123-08:00")
+
+        val actual = Validator.create(DATE_TIME_SCHEMA, ValidatorConfig(validateFormat = FormatValidationPolicy.ALWAYS))
+            .validate(instance)
+
+        assertThat(actual).isNotNull()
+    }
+
+    @Test
     @Disabled
     fun `date-time valid leap second at UTC`() {
         val instance = JsonString("1990-02-31T15:59:59.123-08:00")


### PR DESCRIPTION
Naive attempt to resolve #169 by constraining `date-time` format to [RFC 3339 grammar](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) via regex. I have dropped the custom `DateTimeFormatter` in exchange for the regex - no existing tests seem to be affected. Alternatively, one could opt for belt and suspenders and keep the custom `DateTimeFormatter` around... :thinking: