### PR TITLE
remove test cases (#169, #170) now covered by official test suite

### DIFF
--- a/src/test/kotlin/com/github/erosb/jsonsKema/FormatTest.kt
+++ b/src/test/kotlin/com/github/erosb/jsonsKema/FormatTest.kt
@@ -30,16 +30,6 @@ class FormatTest {
     }
 
     @Test
-    fun date_time_extendedYear() {
-        val instance = JsonString("+11990-03-31T15:59:59.123-08:00")
-
-        val actual = Validator.create(DATE_TIME_SCHEMA, ValidatorConfig(validateFormat = FormatValidationPolicy.ALWAYS))
-            .validate(instance)
-
-        assertThat(actual).isNotNull()
-    }
-
-    @Test
     @Disabled
     fun `date-time valid leap second at UTC`() {
         val instance = JsonString("1990-02-31T15:59:59.123-08:00")
@@ -48,18 +38,6 @@ class FormatTest {
             .validate(instance)
 
         assertThat(actual).isNull()
-    }
-
-    @Test
-    fun uuid_shiftedDashes() {
-        val instance = JsonString("2eb8aa0-8aa98-11e-ab4aa7-3b441d16380")
-
-        val uuidSchema = FormatSchema("uuid", UnknownSource)
-
-        val actual = Validator.create(uuidSchema, ValidatorConfig(validateFormat = FormatValidationPolicy.ALWAYS))
-            .validate(instance)
-
-        assertThat(actual).isNotNull()
     }
 
     @Test


### PR DESCRIPTION
The example scenarios for #169 and #170 are now covered by the official test suite pulled in via git modules:

- https://github.com/json-schema-org/JSON-Schema-Test-Suite/issues/780
- https://github.com/json-schema-org/JSON-Schema-Test-Suite/issues/781

Thus, the custom test cases can be removed.