### PR TITLE
Fix SchemaVisitor to always visit unevaluatedProperties/Items

### DIFF
--- a/src/main/kotlin/com/github/erosb/jsonsKema/SchemaVisitor.kt
+++ b/src/main/kotlin/com/github/erosb/jsonsKema/SchemaVisitor.kt
@@ -83,7 +83,7 @@ abstract class SchemaVisitor<P> {
         return result
     }
 
-    protected open fun shouldVisitUnevaluatedSchemas(result: P?): Boolean = true
+    open fun shouldVisitUnevaluatedSchemas(result: P?): Boolean = true
 
     protected var dynamicPath: DynamicPath = DynamicPath()
 

--- a/src/main/kotlin/com/github/erosb/jsonsKema/SchemaVisitor.kt
+++ b/src/main/kotlin/com/github/erosb/jsonsKema/SchemaVisitor.kt
@@ -76,8 +76,8 @@ abstract class SchemaVisitor<P> {
             .map { visitPatternPropertySchema(it.key, it.value) }
             .reduce { a, b -> accumulate(schema, a, b) }
         result = accumulate(schema, result, patternSchemaProduct)
-            ?: schema.unevaluatedItemsSchema?.accept(this)?.let { accumulate(schema, result, it) }
-            ?: schema.unevaluatedPropertiesSchema?.accept(this)?.let { accumulate(schema, result, it) }
+        schema.unevaluatedItemsSchema?.accept(this)?.let { result = accumulate(schema, result, it) }
+        schema.unevaluatedPropertiesSchema?.accept(this)?.let { result = accumulate(schema, result, it) }
         return result
     }
 

--- a/src/main/kotlin/com/github/erosb/jsonsKema/SchemaVisitor.kt
+++ b/src/main/kotlin/com/github/erosb/jsonsKema/SchemaVisitor.kt
@@ -76,11 +76,14 @@ abstract class SchemaVisitor<P> {
             .map { visitPatternPropertySchema(it.key, it.value) }
             .reduce { a, b -> accumulate(schema, a, b) }
         result = accumulate(schema, result, patternSchemaProduct)
-        schema.unevaluatedItemsSchema?.accept(this)?.let { result = accumulate(schema, result, it) }
-        schema.unevaluatedPropertiesSchema?.accept(this)?.let { result = accumulate(schema, result, it) }
+        if (shouldVisitUnevaluatedSchemas(result)) {
+            schema.unevaluatedItemsSchema?.accept(this)?.let { result = accumulate(schema, result, it) }
+            schema.unevaluatedPropertiesSchema?.accept(this)?.let { result = accumulate(schema, result, it) }
+        }
         return result
     }
 
+    protected open fun shouldVisitUnevaluatedSchemas(result: P?): Boolean = true
 
     protected var dynamicPath: DynamicPath = DynamicPath()
 

--- a/src/main/kotlin/com/github/erosb/jsonsKema/Validator.kt
+++ b/src/main/kotlin/com/github/erosb/jsonsKema/Validator.kt
@@ -416,6 +416,8 @@ private class DefaultValidator(
         return rootSchema.accept(this)
     }
 
+    override fun shouldVisitUnevaluatedSchemas(result: ValidationFailure?): Boolean = result == null
+
     override fun visitCompositeSchema(schema: CompositeSchema): ValidationFailure? {
         if (instance is IJsonArray<*> && schema.unevaluatedItemsSchema != null) {
             return withOtherInstance(markableArray(instance as IJsonArray<IJsonValue>)) {


### PR DESCRIPTION
 SchemaVisitor.visitCompositeSchema() was not visiting unevaluatedPropertiesSchema or unevaluatedItemsSchema when prior subschema results were non-null, due to Kotlin's ?: null-coalescing operator short-circuiting the chain.                                                                                                                                
                                                                                                                                                                                          
In practice, accumulate almost always returns non-null (any subschema or property schema produces a result), so unevaluatedProperties and unevaluatedItems were silently skipped for any schema that had other keywords alongside them.                                                                                                                                    
                                                      